### PR TITLE
Add "Destroy Board" function

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -35,6 +35,13 @@ class BoardsController < ApplicationController
     end
   end
 
+  def destroy
+    @board = Board.find(params[:id])
+    @board.destroy
+
+    redirect_to root_path, status: :see_other
+  end
+
   private
     def board_params
       params.require(:board).permit(:name)

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -2,6 +2,11 @@
 
 <ul>
   <li><%= link_to "Edit", edit_board_path(@board) %></li>
+  <li> <%= link_to "Destroy", board_path(@board),
+        data: {
+        turbo_method: :delete,
+        turbo_confirm: "Are you sure?"
+        } %></li>
 </ul>
 
 <%= link_to "Back to Boards", boards_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <%= javascript_include_tag "turbo", type: "module" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   </head>
 


### PR DESCRIPTION
A line below is needed to add to `application.html.erb` to enable board deletion
```
<%= javascript_include_tag "turbo", type: "module" %>
```

cf: https://discuss.rubyonrails.org/t/guide-v7-0-3-1-link-to-destroy-turbo-method-delete-doesnt-works-ubuntu-22-04/81326/10